### PR TITLE
Fixed casing in import statements.

### DIFF
--- a/projects/ng-select2/src/lib/ng-select2.component.ts
+++ b/projects/ng-select2/src/lib/ng-select2.component.ts
@@ -19,7 +19,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Select2OptionData } from './ng-select2.interface';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 declare var jQuery: any;
 

--- a/src/app/demos/allow-clear/allow-clear.component.ts
+++ b/src/app/demos/allow-clear/allow-clear.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Select2OptionData } from 'ng-select2';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 @Component({
   selector: 'app-allow-clear',

--- a/src/app/demos/custom-array/custom-array.component.ts
+++ b/src/app/demos/custom-array/custom-array.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 @Component({
   selector: 'app-custom-array',

--- a/src/app/demos/multiple/multiple.component.ts
+++ b/src/app/demos/multiple/multiple.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Select2OptionData } from 'ng-select2';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 @Component({
   selector: 'app-multiple',

--- a/src/app/demos/options/options.component.ts
+++ b/src/app/demos/options/options.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Select2OptionData } from 'ng-select2';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 @Component({
   selector: 'app-options',

--- a/src/app/demos/template/template.component.ts
+++ b/src/app/demos/template/template.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Select2OptionData } from 'ng-select2';
-import { Options } from 'Select2';
+import { Options } from 'select2';
 
 import { DataService } from '../../services/data.service';
 


### PR DESCRIPTION
Import from `select2` rather than `Select2`. This appears to affect Linux distros only (i.e. Docker images).